### PR TITLE
60 Follower 목록 페이지 구현

### DIFF
--- a/src/components/common/Top/TopBasicNav.jsx
+++ b/src/components/common/Top/TopBasicNav.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { TopDiv, ArrowLeftBtn, OptionBtn } from '../Top/TopBasicNav.styled';
+import {
+  TopDiv,
+  ArrowLeftBtn,
+  OptionBtn,
+  ArrowLeftBtnText,
+} from '../Top/TopBasicNav.styled';
 
-export default function TopBasicNav() {
+export default function TopBasicNav({ children }) {
   return (
     <TopDiv>
       <ArrowLeftBtn />
+      <ArrowLeftBtnText>{children}</ArrowLeftBtnText>
       <OptionBtn />
     </TopDiv>
   );

--- a/src/components/common/Top/TopBasicNav.styled.js
+++ b/src/components/common/Top/TopBasicNav.styled.js
@@ -13,6 +13,8 @@ const TopDiv = styled.div`
   position: fixed;
   background-color: white;
   z-index: 10;
+  left: 0;
+  top: 0;
 `;
 const ArrowLeftBtn = styled.button`
   background-color: inherit;
@@ -29,4 +31,10 @@ const OptionBtn = styled.button`
   background: url(${optionImg}) no-repeat center / contain;
 `;
 
-export { TopDiv, ArrowLeftBtn, OptionBtn };
+const ArrowLeftBtnText = styled.span`
+  margin-right: auto;
+  padding-left: 1rem;
+  font-size: 1.4rem;
+`;
+
+export { TopDiv, ArrowLeftBtn, OptionBtn, ArrowLeftBtnText };

--- a/src/pages/Profile/Follower/Follower.jsx
+++ b/src/pages/Profile/Follower/Follower.jsx
@@ -1,5 +1,65 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import TopBasicNav from '../../../components/common/Top/TopBasicNav';
+import FollowerUser from './FollowerUser';
+import TabMenu from '../../../components/common/Tabmenu/TabMenu';
+
+import { UserWrapper } from './Follower.styled';
+import { instance } from '../../../util/api/axiosInstance';
+import { useLocation } from 'react-router-dom';
 
 export default function Follower() {
-  return <div>Follower</div>;
+  const token = localStorage.getItem('token');
+
+  const [followers, setFollowers] = useState([]);
+  const location = useLocation();
+  const accountName = location.state;
+  console.log(accountName);
+
+  /* 
+    2. 버튼 눌렀을 때 getFollowers 가 실행이 되고 서버와 통신해서 setFollowers에 나를 팔로우한 사람들의 데이터를 넣는다.
+    그렇게 되면 빈 배열이 아니라 값이 채워지게 되고, 아래 return 문으로 가게 되면
+  */
+  const getFollowers = async () => {
+    const res = await instance.get(
+      `https://api.mandarin.weniv.co.kr/profile/${accountName}/follower`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
+      },
+    );
+    setFollowers(res.data);
+  };
+
+  // useEffect(콜백함수, 의존성 배열)
+  // 의존성 배열의 요소가 변경되면 콜백함수 실행
+  useEffect(() => {
+    getFollowers();
+  }, []);
+
+  return (
+    <>
+      <TopBasicNav>Followers</TopBasicNav>
+      <UserWrapper>
+        {/* 3. 이곳에 useState에 채워져있는 배열이 map으로 뿌려지게 되고, 빈 화면이 아니라 유저들의 정보가 화면에 뿌려지게 된다. */}
+        {followers.map((user) => {
+          return (
+            <li key={user._id}>
+              <FollowerUser
+                size={'small'}
+                userName={user.username}
+                userIntro={user.Intro}
+                userImg={user.image}
+                type={user.isfollow && 'follow'}
+              />
+            </li>
+          );
+        })}
+
+        {/* 1. 버튼을 클릭하지 않으면 서버와 통신하지 않아 useState의 followers에 값이 들어가지 않음. 따라서 useState의 초기값인 빈 배열이 생성 */}
+      </UserWrapper>
+      <TabMenu></TabMenu>
+    </>
+  );
 }

--- a/src/pages/Profile/Follower/Follower.styled.js
+++ b/src/pages/Profile/Follower/Follower.styled.js
@@ -1,0 +1,8 @@
+import { styled } from 'styled-components';
+
+const UserWrapper = styled.ul`
+  margin-top: 7rem;
+  margin-left: 2.5rem;
+`;
+
+export { UserWrapper };

--- a/src/pages/Profile/Follower/FollowerUser.jsx
+++ b/src/pages/Profile/Follower/FollowerUser.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import * as S from './FollowerUser.styled';
+import StyledBtn from '../../../components/common/Button/Button';
+
+export default function FollowerUser({
+  size,
+  userName,
+  userIntro,
+  userImg,
+  type,
+}) {
+  const [followState, setFollowState] = useState(
+    type === 'follow' ? true : false,
+  );
+
+  /* User컴포넌트를 여러곳에서 쓰고 싶을 때 if문 사용 */
+  //   const button = () => {
+  //     if(type === 'follow') {
+  //       return (
+  //         <StyledBtn
+  //           size={'l'}
+  //           width={100}
+  //           color={type === 'follow' ? 'outline' : ''}
+  //           onClick={}
+  //           to={false}>
+  //         {type === 'follow' ? '취소' : '팔로우'}
+  //         </StyledBtn>
+  //       )
+  //     } else if(type === 'unfollow') {
+  //       return (
+  //        <StyledBtn />
+  //       )
+  //     }
+
+  //   }
+
+  return (
+    <S.FollowerUserWrapper>
+      <S.FollowerUserStyled>
+        <S.FollowerUserImage size={size} src={userImg} alt="사용자 이미지" />
+        <S.FollowerUserTextBox>
+          <S.FollowerUserName>{userName}</S.FollowerUserName>
+          <S.FollowerUserIntro>{userIntro}</S.FollowerUserIntro>
+        </S.FollowerUserTextBox>
+
+        <S.BtnBox>
+          {/* 삼항 연산자는 값이 2개로 나뉠 때만 쓰는 것이 가독성이 좋음 */}
+          <StyledBtn
+            size={'s'}
+            width={'10'}
+            color={followState === true ? 'outline' : ''}
+            onClick={() => setFollowState(!followState)}
+            to={false}
+          >
+            {followState === true ? '취소' : '팔로우'}
+          </StyledBtn>
+        </S.BtnBox>
+        {/* if문으로 컴포넌트 처리해야 할 때 쓰는 버튼 */}
+        {/* {button()} */}
+      </S.FollowerUserStyled>
+    </S.FollowerUserWrapper>
+  );
+}

--- a/src/pages/Profile/Follower/FollowerUser.styled.js
+++ b/src/pages/Profile/Follower/FollowerUser.styled.js
@@ -1,0 +1,41 @@
+import { styled } from 'styled-components';
+
+export const FollowerUserWrapper = styled.div``;
+
+export const FollowerUserStyled = styled.div`
+  display: flex;
+  width: 100%;
+  gap: 1.2rem;
+`;
+
+export const FollowerUserImage = styled.img`
+  width: ${(props) => (props.size === 'small' ? '4.2rem' : '5rem')};
+  height: ${(props) => (props.size === 'small' ? '4.2rem' : '5rem')};
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export const FollowerUserTextBox = styled.div`
+  margin-left: 0.5rem;
+  margin-top: 0.5rem;
+`;
+
+export const FollowerUserIntro = styled.div`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  color: #767676;
+`;
+
+export const FollowerUserName = styled.p`
+  font-size: 1.4rem;
+  font-weight: 500;
+  margin-top: 0.5rem;
+`;
+
+export const BtnBox = styled.div`
+  padding-right: 2rem;
+  margin-left: auto;
+  margin-top: 0.5rem;
+`;

--- a/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
+++ b/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
@@ -5,6 +5,7 @@ import ProductItem from '../../../components/common/ProductItem/ProductItem';
 import PostItem from '../../../components/common/PostItem/PostItem';
 import TabMenu from '../../../components/common/Tabmenu/TabMenu';
 import StyledBtn from '../../../components/common/Button/Button';
+import { Link } from 'react-router-dom';
 
 import * as S from './ProfileDetail.styled';
 
@@ -37,16 +38,18 @@ export default function Profile() {
     itemImg: 'https://picsum.photos/200',
   };
 
+  const accountname = 'mong';
+
   return (
     <>
       <TopBasicNav />
       <S.Container>
         <S.ProfileSection>
           <S.ProfileWrap>
-            <S.followWrap>
+            <Link to="/follower" state={accountname}>
               <p>{Dummy.followers}</p>
               <p>followers</p>
-            </S.followWrap>
+            </Link>
             <S.ProfileImg src={Dummy.userImg} alt="프로필 사진" />
             <S.followWrap>
               <p>{Dummy.followings}</p>


### PR DESCRIPTION
## Summary

- 팔로워 페이지 기본 기능 구현
- TopBasicNav 컴포넌트 수정
- ProfileDetail 컴포넌트 수정

## Description

- 팔로워 페이지 UI 구현
- 페이지 내 사용되는 TopBasicNav 컴포넌트에 children 속성 추가하여 텍스트 처리하도록 수정
- follow 상태값에 따라 버튼 변경
- useEffect를 사용하여 컴포넌트가 마운트 되었을 때 즉시 데이터 받아오도록 처리
- 팔로워 목록 api 연결
- ProfileDetail 컴포넌트에서 Link 태그 사용하여 클릭시 /follower 페이지로 넘어감과 동시에 accountName 값을 전달하도록 수정

## Checklist

- 화면에 잘 뜨는지 확인 부탁드립니다.
- 데이터 잘 들어오는지, 버튼 변경되는지 확인 부탁드립니다.
