### PR TITLE
Feat: ProfileDetail 페이지 BottomSheetModal 포탈로 구현 (#82)

### DIFF
--- a/src/components/common/Alert/Alert.jsx
+++ b/src/components/common/Alert/Alert.jsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import * as S from './Alert.styled';
+import { createPortal } from 'react-dom';
 
-export default function Alert({ title, cancel, action, actionText }) {
+export default function Alert({ isOpen, title, cancel, action, actionText }) {
   return (
-    <S.Alert>
-      <p>{title}</p>
-      <div>
-        <button type="button" onClick={cancel}>
-          취소
-        </button>
-        <button type="button" onClick={action}>
-          {actionText}
-        </button>
-      </div>
-    </S.Alert>
+    isOpen &&
+    createPortal(
+      <S.Overlay>
+        <S.Alert>
+          <p>{title}</p>
+          <div>
+            <button type="button" onClick={cancel}>
+              취소
+            </button>
+            <button type="button" onClick={action}>
+              {actionText}
+            </button>
+          </div>
+        </S.Alert>
+      </S.Overlay>,
+      document.body,
+    )
   );
 }

--- a/src/components/common/Alert/Alert.styled.js
+++ b/src/components/common/Alert/Alert.styled.js
@@ -1,5 +1,17 @@
 import { styled } from 'styled-components';
 
+export const Overlay = styled.div`
+  position: fixed;
+  content: '';
+  inset: 0;
+  z-index: 100;
+  background-color: rgb(0, 0, 0, 0.3);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 export const Alert = styled.div`
   width: 25.2rem;
   height: 11rem;
@@ -7,6 +19,8 @@ export const Alert = styled.div`
   display: flex;
   flex-direction: column;
   text-align: center;
+  background-color: #fff;
+  transition: all 0.3s;
 
   p {
     padding-top: 2.2rem;

--- a/src/components/common/BottomSheetModal/BottomSheetModal.jsx
+++ b/src/components/common/BottomSheetModal/BottomSheetModal.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
-import Modal from './BottomSheetModal.styled';
+import { Modal, Overlay } from './BottomSheetModal.styled';
+import { createPortal } from 'react-dom';
 
-const BottomSheetModal = ({ children }) => {
-  console.log(children);
+const BottomSheetModal = ({ isOpen, children }) => {
   return (
-    <Modal>
-      <span></span>
-      {children.map((child, index) => (
-        <li key={index}>{child}</li>
-      ))}
-    </Modal>
+    isOpen &&
+    createPortal(
+      <Overlay>
+        <Modal>
+          <span></span>
+          {children.map((child, index) => (
+            <li key={index}>{child.name}</li>
+          ))}
+        </Modal>
+      </Overlay>,
+      document.body,
+    )
   );
 };
 

--- a/src/components/common/BottomSheetModal/BottomSheetModal.styled.js
+++ b/src/components/common/BottomSheetModal/BottomSheetModal.styled.js
@@ -3,12 +3,15 @@ import { styled } from 'styled-components';
 const Modal = styled.div`
   border-radius: 1rem 1rem 0 0;
   width: 100vw;
+
   span {
+    height: 10px;
     height: 0.4rem;
-    width: 5rem;
+    width: 7rem;
     background-color: #dbdbdb;
     border-radius: 5rem;
-    margin: 1.6rem auto;
+    margin: 2rem auto;
+
     display: block;
   }
 
@@ -26,4 +29,23 @@ const Modal = styled.div`
   }
 `;
 
-export default Modal;
+const Overlay = styled.div`
+  border-top-right-radius: 1rem;
+  border-top-left-radius: 1rem;
+  border: solid 0.1rem #c4c4c4;
+  /* height: 25%; */
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  content: '';
+  /* inset: 0; */
+  z-index: 100;
+  /* background-color: rgb(0, 0, 0, 0.3); */
+  background-color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export { Modal, Overlay };

--- a/src/components/common/Top/TopBasicNav.jsx
+++ b/src/components/common/Top/TopBasicNav.jsx
@@ -6,12 +6,12 @@ import {
   ArrowLeftBtnText,
 } from '../Top/TopBasicNav.styled';
 
-export default function TopBasicNav({ children }) {
+export default function TopBasicNav({ children, openModal }) {
   return (
     <TopDiv>
       <ArrowLeftBtn />
       <ArrowLeftBtnText>{children}</ArrowLeftBtnText>
-      <OptionBtn />
+      <OptionBtn onClick={() => openModal()} />
     </TopDiv>
   );
 }

--- a/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
+++ b/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
@@ -1,7 +1,5 @@
-import { useLocation } from 'react-router-dom';
-/* eslint-disable */
-import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import React, { useEffect, useState, useRef } from 'react';
+import { useParams } from 'react-router-dom';
 
 import TopBasicNav from '../../../components/common/Top/TopBasicNav';
 import ProductItem from '../../../components/common/ProductItem/ProductItem';
@@ -11,6 +9,7 @@ import StyledBtn from '../../../components/common/Button/Button';
 
 import { instance } from '../../../util/api/axiosInstance';
 import useScrollBottom from '../../../hooks/useScrollBottom';
+import BottomSheetModal from '../../../components/common/BottomSheetModal/BottomSheetModal';
 
 import * as S from './ProfileDetail.styled';
 
@@ -23,9 +22,9 @@ export default function Profile() {
   const { id } = useParams();
 
   // TODO: 변경해야함
-  const accountName = process.env.REACT_APP_ACCOUNT_NAME;
-  const myId = process.env.REACT_APP_USER_ID;
-  const token = process.env.REACT_APP_USER_TOKEN;
+  const accountName = 'kikikik';
+  const myId = '6476d76ab2cb2056632cffd8';
+  const token = localStorage.getItem('token');
 
   const loadProfile = async (accName) => {
     try {
@@ -113,11 +112,37 @@ export default function Profile() {
     loadPost(accountName);
   }, [isBottom]);
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const modal = useRef(null);
+
+  const openModal = () => {
+    setIsModalOpen(!isModalOpen);
+    //누를때마다 setModalOpen의 상태가 true,false로 변하면서 모달창이 생겼다 없어졌다
+  };
+
+  const ModalArr = [
+    { name: '삭제' },
+    { name: '수정' },
+    { name: '한수정' },
+    { name: '숮엉' },
+  ];
+
   return (
     <>
-      <TopBasicNav />
+      <TopBasicNav openModal={openModal} />
       <S.Container>
         <S.ProfileSection>
+          <BottomSheetModal
+            ref={modal}
+            isOpen={isModalOpen}
+            title="로그아웃 하시겠어요?"
+            cancel={() => setIsModalOpen(false)}
+            actionText="로그아웃"
+            action={() => console.log('로그아웃')}
+          >
+            {ModalArr}
+          </BottomSheetModal>
           <S.ProfileWrap>
             <S.followLink to="/follower" state={profile.accountname}>
               <p>{profile.followerCount}</p>


### PR DESCRIPTION
## Summary

ProfileDetail 페이지 BottomSheetModal 포탈로 구현

## Description

- 기존 BottomSheetModal UI를 ProfileDetail 페이지에 포탈 사용하여 연결
- TopBasicNav의 우측 option버튼을 누르면 모달창이 뜨고, 없어지도록 구현
- 페이지에서 데이터를 ModalArr에 넣고 그것을 BottomSheetModal에 props로 전달하여 띄워줌
- TODO: Alert창과 연결, BottomSheet 사용하는 다른 페이지도 작업

## Checklist

모달창 잘 뜨는지 확인 부탁드립니다 !
