### PR TITLE
98 탭메뉴 각 페이지 경로따라 아이콘 변하도록 구현

### DIFF
--- a/src/assets/img/more-btn-active.svg
+++ b/src/assets/img/more-btn-active.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" y="3" width="18" height="18" rx="3" stroke="#AA6EC9" stroke-width="2"/>
+<path d="M12 8V16" stroke="#AA6EC9" stroke-width="2" stroke-linecap="round"/>
+<path d="M8 12L16 12" stroke="#AA6EC9" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/common/Tabmenu/TabMenu.jsx
+++ b/src/components/common/Tabmenu/TabMenu.jsx
@@ -17,7 +17,7 @@ import { useLocation } from 'react-router-dom';
 export default function TabMenu() {
   const currentUserData = useRecoilValue(recoilData);
 
-  const lacation = useLocation();
+  const location = useLocation();
 
   return (
     <>
@@ -25,7 +25,7 @@ export default function TabMenu() {
         <TabMenuLi>
           <TabMenuLiLink to="/home">
             <img
-              src={lacation.pathname === '/home' ? ActiveHome : home}
+              src={location.pathname === '/home' ? ActiveHome : home}
               alt="홈"
             />
             <p

--- a/src/components/common/Tabmenu/TabMenu.jsx
+++ b/src/components/common/Tabmenu/TabMenu.jsx
@@ -3,38 +3,104 @@ import home from '../../../assets/img/icon-home.svg';
 import messageCircle from '../../../assets/img/icon-message-circle.svg';
 import addPost from '../../../assets/img/icon-edit.svg';
 import user from '../../../assets/img/icon-user.svg';
+
+import ActiveHome from '../../../assets/img/icon-home-fill.svg';
+import ActiveMessageCircle from '../../../assets/img/icon-message-circle-fill.svg';
+import ActiveAddPost from '../../../assets/img/more-btn-active.svg';
+import ActiveUser from '../../../assets/img/icon-user-fill.svg';
+
 import { TabMenuUl, TabMenuLi, TabMenuLiLink } from './TabMenu.styled';
 import { useRecoilValue } from 'recoil';
 import { recoilData } from '../../../recoil/atoms/dataState';
+import { useLocation } from 'react-router-dom';
 
 export default function TabMenu() {
   const currentUserData = useRecoilValue(recoilData);
+
+  const lacation = useLocation();
 
   return (
     <>
       <TabMenuUl>
         <TabMenuLi>
           <TabMenuLiLink to="/home">
-            <img src={home} alt="홈" />
-            <p>홈</p>
+            <img
+              src={lacation.pathname === '/home' ? ActiveHome : home}
+              alt="홈"
+            />
+            <p
+              style={{
+                color:
+                  location.pathname === '/home' ? '#F26E22' : 'var(--sub-grey)',
+              }}
+            >
+              홈
+            </p>
           </TabMenuLiLink>
         </TabMenuLi>
         <TabMenuLi>
           <TabMenuLiLink to="/chatlist">
-            <img src={messageCircle} alt="채팅" />
-            <p>채팅</p>
+            <img
+              src={
+                location.pathname === '/chatlist'
+                  ? ActiveMessageCircle
+                  : messageCircle
+              }
+              alt="채팅"
+            />
+            <p
+              style={{
+                color:
+                  location.pathname === '/chatlist'
+                    ? '#F26E22'
+                    : 'var(--sub-grey)',
+              }}
+            >
+              채팅
+            </p>
           </TabMenuLiLink>
         </TabMenuLi>
         <TabMenuLi>
           <TabMenuLiLink to="/post/upload">
-            <img src={addPost} alt="게시물 작성" />
-            <p>게시물 작성</p>
+            <img
+              src={
+                location.pathname === '/post/upload' ? ActiveAddPost : addPost
+              }
+              alt="게시물 작성"
+            />
+            <p
+              style={{
+                color:
+                  location.pathname === '/post/upload'
+                    ? '#F26E22'
+                    : 'var(--sub-grey)',
+              }}
+            >
+              게시물 작성
+            </p>
           </TabMenuLiLink>
         </TabMenuLi>
         <TabMenuLi>
           <TabMenuLiLink to={`/profile/${currentUserData.accountname}`}>
-            <img src={user} alt="프로필" />
-            <p>프로필</p>
+            <img
+              src={
+                location.pathname === `/profile/${currentUserData.accountname}`
+                  ? ActiveUser
+                  : user
+              }
+              alt="프로필"
+            />
+            <p
+              style={{
+                color:
+                  location.pathname ===
+                  `/profile/${currentUserData.accountname}`
+                    ? '#F26E22'
+                    : 'var(--sub-grey)',
+              }}
+            >
+              프로필
+            </p>
           </TabMenuLiLink>
         </TabMenuLi>
       </TabMenuUl>

--- a/src/pages/Profile/ProfileEdit/ProfileEdit.jsx
+++ b/src/pages/Profile/ProfileEdit/ProfileEdit.jsx
@@ -36,7 +36,7 @@ export default function ProfileEdit() {
   console.log(currentUserData);
 
   const gotAccountName = currentUserData.accountname;
-  const gotUserId = currentUserData._id;
+  // const gotUserId = currentUserData._id;
   const token = useRecoilValue(loginState);
 
   useEffect(() => {
@@ -140,7 +140,7 @@ export default function ProfileEdit() {
 
       console.log(res);
 
-      navigate(`/profile/${gotUserId}`);
+      navigate(`/profile/${gotAccountName}`);
     } catch (error) {
       console.error(error);
 


### PR DESCRIPTION
## Summary

탭메뉴 각 페이지 경로따라 아이콘 변하도록 구현

## Description

-탭메뉴 아이콘을 각 페이지 경로에 따라 활성화 상태의 아이콘으로 변하도록 구현
- 아이콘 하단 폰트 색상도 활성화 상태일 때 함께 변하도록 구현
- 기타: profileDetail > navigate(‘/profile/)부분 기존 id에서 account로 변경 (프로필 수정 후 저장하면 로그인 해제되는 오류 해결)
## Checklist

- 리뷰어가 확인해야할 내용
