### PR TITLE
155 [ProfileDetail] 게시글 랜더링 오류 수정

### DIFF
--- a/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
+++ b/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
@@ -88,7 +88,6 @@ export default function Profile() {
       alert(`${error.response.data.message}`);
     }
   };
-  console.log(posts);
 
   const followHandler = async () => {
     try {
@@ -133,7 +132,9 @@ export default function Profile() {
     }
   }, [isBottom]);
   useEffect(() => {
-    loadPost(accountName);
+    if (skip > 0) {
+      loadPost(accountName);
+    }
   }, [skip]);
 
   const deletePost = async (postId) => {


### PR DESCRIPTION
## Summary

프로필 페이지에서 게시글이 제대로 되지 않은 오류 수정

## Description

- 다른 사람의 프로필 페이지에서 내 프로필 페이지로 이동할 때 문제 발생
- 프로필 페이지에서 2번의 중복 요청이 발생하면서 2번째 요청의 응답이 오기 전에 내 프로필로 이동하면서 다른 사람의 게시물의 보임
- 중복 요청을 제거

## Checklist

- 다른 사람의 프로필 페이지에서 내 프로필 페이지로 이동하면서 게시글 잘 나오는지 확인해주세요
