### PR TITLE
165 [Post] z-index 수정

### DIFF
--- a/src/components/common/Top/TopUploadNav.styled.js
+++ b/src/components/common/Top/TopUploadNav.styled.js
@@ -13,6 +13,7 @@ const TopDiv = styled.div`
   background-color: white;
   top: 0;
   left: 0;
+  z-index: 10;
 `;
 const ArrowLeftBtn = styled.button`
   width: 2.2rem;


### PR DESCRIPTION
## Summary

게시글 등록/수정 페이지에서 Top 컴포넌트가 본문 뒤에 오는 오류 수정

## Description

- TopUploadNav 컴포넌트의 z-index가 설정되어있지 않아 코드 순서상 아래에 있는 컴포넌트가 TopUploadNav보다 위에 올라옴
- TopUploadNav 컴포넌트에 z-index: 10 설정

## Checklist

- 게시글 등록/수정 페이지에서 확인해주세요.
