### PR TITLE
157 [Chat] 채팅 페이지 랜더링 오류 수정

### DIFF
--- a/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
+++ b/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
@@ -222,7 +222,13 @@ export default function Profile() {
             </S.UserBtnWrap>
           ) : (
             <S.UserBtnWrap>
-              <S.messageButton to={`/chatlist/${accountname}`} />
+              <S.messageButton
+                to={`/chatlist/${accountname}`}
+                state={{
+                  userName: profile.username,
+                  userImg: profile.image,
+                }}
+              />
               <StyledBtn
                 size="m"
                 color={profile.isfollow ? 'outlineGrey' : 'fill'}


### PR DESCRIPTION
## Summary

타 유저 프로필에서 채팅 버튼 클릭시 해당 유저와의 채팅방으로 이동하도록 라우터 수정

## Description

- 타유저 프로필 채팅 클릭시 채팅방으로 이동하도록 라우터 연결

TODO
- 마크업만 된 페이지라서 실제 채팅방 서버 연결시 전체적으로 수정 필요

## Checklist

- 채팅방 마크업페이지로 잘 연결되는지 확인 부탁드립니다.
