### PR TITLE
208 [follower, following] accountname 받는 방법 수정

### DIFF
--- a/src/pages/Profile/Follower/Follower.jsx
+++ b/src/pages/Profile/Follower/Follower.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
 import TopBasicNav from '../../../components/common/Top/TopBasicNav';
 import FollowerUser from './FollowerUser';
 import TabMenu from '../../../components/common/Tabmenu/TabMenu';
 import { UserWrapper } from './Follower.styled';
-import { useLocation } from 'react-router-dom';
 import { recoilData } from '../../../recoil/atoms/dataState';
-import { useRecoilValue } from 'recoil';
 import { useFollowStatus } from '../../../hooks/react-query/useFollowStatus';
 
 export default function Follower() {
-  const location = useLocation();
-  const { accountName, myAccountName } = location.state;
-  const token = useRecoilValue(recoilData).token;
+  const { accountname } = useParams();
+  const { token, accountname: myAccountname } = useRecoilValue(recoilData);
   const { followers, unfollowMutation, followMutation } = useFollowStatus(
-    accountName,
+    accountname,
     token,
   );
 
@@ -39,7 +39,7 @@ export default function Follower() {
 
           // find 사용하여 내 계정 찾기
           const myAccount = followers.find(
-            (user) => user.accountname === myAccountName,
+            (user) => user.accountname === myAccountname,
           );
 
           // filter 사용하여 다른 사람의 계정만 필터링
@@ -57,7 +57,7 @@ export default function Follower() {
                 userInfo={user}
                 followHandler={followHandler}
                 size={'small'}
-                myAccountName={myAccountName}
+                myAccountName={myAccountname}
               />
             </li>
           ));

--- a/src/pages/Profile/Following/Following.jsx
+++ b/src/pages/Profile/Following/Following.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
 import TopBasicNav from '../../../components/common/Top/TopBasicNav';
 import FollowingUser from './FollowingUser';
 import TabMenu from '../../../components/common/Tabmenu/TabMenu';
 import { UserWrapper } from './Following.styled';
-import { useLocation } from 'react-router-dom';
 import { recoilData } from '../../../recoil/atoms/dataState';
-import { useRecoilValue } from 'recoil';
 import { useFollowStatus } from '../../../hooks/react-query/useFollowStatus';
 
 export default function Following() {
-  const location = useLocation();
-  const { accountName, myAccountName } = location.state;
-  const token = useRecoilValue(recoilData).token;
+  const { accountname } = useParams();
+  const { token, accountname: myAccountname } = useRecoilValue(recoilData);
   const { followings, unfollowMutation, followMutation } = useFollowStatus(
-    accountName,
+    accountname,
     token,
   );
 
@@ -39,7 +39,7 @@ export default function Following() {
 
           // find 사용하여 내 계정 찾기
           const myAccount = followings.find(
-            (user) => user.accountname === myAccountName,
+            (user) => user.accountname === myAccountname,
           );
 
           // filter 사용하여 다른 사람의 계정만 필터링
@@ -59,7 +59,7 @@ export default function Following() {
                 userInfo={user}
                 followHandler={followHandler}
                 size={'small'}
-                myAccountName={myAccountName}
+                myAccountName={myAccountname}
               />
             </li>
           ));

--- a/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
+++ b/src/pages/Profile/ProfileDetail/ProfileDetail.jsx
@@ -76,13 +76,7 @@ export default function Profile() {
       <S.Container>
         <S.ProfileSection>
           <S.ProfileWrap>
-            <S.followLink
-              to="/follower"
-              state={{
-                accountName: profile.accountname,
-                myAccountName: myAccountName,
-              }}
-            >
+            <S.followLink to="follower">
               <p>{profile.followerCount}</p>
               <p>followers</p>
             </S.followLink>
@@ -91,13 +85,7 @@ export default function Profile() {
               onError={handleImageError}
               alt="프로필 사진"
             />
-            <S.followLink
-              to="/following"
-              state={{
-                accountName: profile.accountname,
-                myAccountName: myAccountName,
-              }}
-            >
+            <S.followLink to="following">
               <p>{profile.followingCount}</p>
               <p>followings</p>
             </S.followLink>

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -45,10 +45,12 @@ export default function Router() {
         </Route>
         <Route path="productupload" element={<ProductUpload />} />
         <Route path="product/edit/:id" element={<ProductEdit />} />
-        <Route path="/follower" element={<Follower />} />
-        <Route path="/following" element={<Following />} />
         <Route path="/profile">
-          <Route path=":accountname" element={<Profile />} />
+          <Route path=":accountname">
+            <Route index element={<Profile />} />
+            <Route path="follower" element={<Follower />} />
+            <Route path="following" element={<Following />} />
+          </Route>
           <Route path="edit" element={<ProfileEdit />} />
         </Route>
       </Route>


### PR DESCRIPTION
## Summary

follower, following 페이지 accountname 받는 방법 수정

## Description

- accountname을 프로필 페이지에서 받아 lighthouse 측정이 안 되는 문제가 있음
- Link의 state로 전달하는 방법에서 useParams로 받는 방법으로 변경

## Checklist

- follower, following 페이지에서 라이트하우스 측정 되는지 확인해주세요.
