### PR TITLE
213 이미지 캐러셀 구현

### DIFF
--- a/src/components/common/Carousel/Carousel.jsx
+++ b/src/components/common/Carousel/Carousel.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+
+import * as S from './Carousel.styled';
+
+export default function Carousel({ images, ...props }) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const imageArray = images.split(',');
+
+  const prevSlide = () => {
+    setCurrentIndex(
+      (prevIndex) => (prevIndex - 1 + imageArray.length) % imageArray.length,
+    );
+  };
+
+  const nextSlide = () => {
+    setCurrentIndex((prevIndex) => (prevIndex + 1) % imageArray.length);
+  };
+
+  return (
+    <S.CarouselContainer>
+      <S.Image
+        src={imageArray[currentIndex]}
+        alt={'게시글 이미지'}
+        {...props}
+      />
+      {imageArray.length > 1 && (
+        <>
+          <S.SlideButton
+            onClick={(e) => {
+              e.target === e.currentTarget && prevSlide();
+            }}
+          >
+            &#8249;
+          </S.SlideButton>
+          <S.SlideButton
+            onClick={(e) => {
+              if (e.target === e.currentTarget) nextSlide();
+            }}
+          >
+            &#8250;
+          </S.SlideButton>
+          <S.CarouselIndicator>
+            {imageArray.map((_, index) => (
+              <S.CarouselIndicatorItem
+                key={index}
+                $currentImage={currentIndex === index}
+              />
+            ))}
+          </S.CarouselIndicator>
+        </>
+      )}
+    </S.CarouselContainer>
+  );
+}

--- a/src/components/common/Carousel/Carousel.styled.js
+++ b/src/components/common/Carousel/Carousel.styled.js
@@ -1,0 +1,57 @@
+const { styled } = require('styled-components');
+
+export const CarouselContainer = styled.div`
+  height: 100%;
+  position: relative;
+  margin-bottom: 1.2rem;
+`;
+
+export const Image = styled.img`
+  display: block;
+  width: 100%;
+  aspect-ratio: 4/3;
+  object-fit: contain;
+  background-color: rgb(245, 245, 245);
+  border-radius: 1rem;
+`;
+
+export const SlideButton = styled.button`
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 20%;
+  background-color: transparent;
+  font-size: 8rem;
+  color: transparent;
+
+  &:hover {
+    color: var(--main-purple);
+    transition: 0.2s color;
+  }
+
+  &:first-of-type {
+    left: 0;
+  }
+
+  &:last-of-type {
+    right: 0;
+  }
+`;
+
+export const CarouselIndicator = styled.div`
+  position: absolute;
+  left: 50%;
+  bottom: 1rem;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 1rem;
+`;
+
+export const CarouselIndicatorItem = styled.span`
+  width: 1rem;
+  height: 1rem;
+  border: 0.1rem solid var(--sub-grey);
+  border-radius: 50%;
+  background-color: ${({ $currentImage }) =>
+    $currentImage ? 'var(--main-purple)' : 'white'};
+`;

--- a/src/components/common/PostItem/PostItem.jsx
+++ b/src/components/common/PostItem/PostItem.jsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil';
 import { instance } from '../../../util/api/axiosInstance';
 
 import User from '../User/User';
+import Carousel from '../Carousel/Carousel';
 import { useAlert, useBottomSheet } from '../../../hooks/useModal';
 import { recoilData } from '../../../recoil/atoms/dataState';
 import useTag from '../../../hooks/useTag';
@@ -133,14 +134,8 @@ export default function PostItem({
         <S.PostContainer>
           <S.PostLink to={`/post/${postId}`} state={{ userId, user_id }}>
             <S.PostText>{contentWithoutTag(postText)}</S.PostText>
-            {postImg &&
-              postImg
-                .split(',')
-                .map((image, index) => (
-                  <S.PostImage key={index} src={image} alt={`게시글 이미지 `} />
-                ))}
           </S.PostLink>
-
+          {postImg && <Carousel images={postImg} />}
           <S.PostButtons>
             <S.PostLike onClick={submitLike} isLiked={isLiked} />
             <S.PostSpan>{likeCount}</S.PostSpan>

--- a/src/components/common/PostItem/PostItem.styled.js
+++ b/src/components/common/PostItem/PostItem.styled.js
@@ -23,14 +23,6 @@ export const PostText = styled.p`
   word-break: break-all;
 `;
 
-export const PostImage = styled.img`
-  display: block;
-  width: 100%;
-  aspect-ratio: 4/3;
-  margin-bottom: 1.2rem;
-  border-radius: 1rem;
-`;
-
 export const PostButtons = styled.div`
   display: flex;
   margin-bottom: 1.6rem;


### PR DESCRIPTION
## Summary

캐러셀 구현

## Description

- 기존 PostItem 컴포넌트는 모든 이미지를 보여줘 화면의 많은 부분을 차지했습니다.
- 캐러셀 컴포넌트를 구현해 이미지를 넘겨서 보는 방식으로 변경했습니다.

## Checklist

- 여러 이미지가 있는 게시글에서 확인해주세요.
