### PR TITLE
Fix: 태그 없는 게시글 수정 시 에러 수정 (#218)

### DIFF
--- a/src/hooks/useTag.js
+++ b/src/hooks/useTag.js
@@ -32,7 +32,7 @@ const useTag = () => {
   };
 
   const getTagInContent = (content) => {
-    const tag = content.match(tagRegex)[0].slice(6, -1);
+    const tag = content.match(tagRegex)?.[0].slice(6, -1);
     return tag;
   };
 


### PR DESCRIPTION
## Summary

게시글 수정시 에러 해결

## Description

- 태그 없는 게시글 수정 시 null값에 접근해 에러 발생
- 옵셔널 체이닝으로 null값인 경우 연산 종료하도록 수정
```js
  const getTagInContent = (content) => {
    const tag = content.match(tagRegex)?.[0].slice(6, -1);
    return tag;
  };
```


## Checklist

- 태그 선택하지 않고 게시글 작성 후 수정해서 확인해주세요.
