### PR TITLE
225 [Search] 리액트 쿼리 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.4.0",
-    "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/hooks/react-query/useSearch.js
+++ b/src/hooks/react-query/useSearch.js
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { instance } from "../../util/api/axiosInstance";
+
+const getSearchData = async (keyword) => {
+    const res = await instance.get(`/user/searchuser/?keyword=${keyword}`);
+    return res.data;
+}
+
+export const useGetResult = (keyword) => {
+    const { data: searchedResult } = useQuery({
+        queryKey: ['keyword', keyword],
+        queryFn: () => getSearchData(keyword),
+        placeholderData: [],
+        enabled: !!keyword,
+        select: (data) => data.slice(0, 100),
+    })
+    return { searchedResult };
+}

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import { SearchWrap, UserListLi } from './Search.styled';
 
@@ -6,68 +6,38 @@ import TopSearchNav from '../../components/common/Top/TopSearchNav';
 import TabMenu from '../../components/common/Tabmenu/TabMenu';
 import User from '../../components/common/User/User';
 
-import { instance } from '../../util/api/axiosInstance';
-
-import { useRecoilValue } from 'recoil';
-import { recoilData } from '../../recoil/atoms/dataState';
-import { debounce } from 'lodash';
+import { useGetResult } from '../../hooks/react-query/useSearch';
 
 export default function Search() {
   const [keywordToSearchUser, setKeywordToSearchUser] = useState('');
-  const [data, setData] = useState([]);
-
-  const token = useRecoilValue(recoilData).token;
-
-  const sendQuery = async () => {
-    if (!keywordToSearchUser) return;
-    const res = await instance.get(
-      `/user/searchuser/?keyword=${keywordToSearchUser}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    setData(res.data);
-  };
-
-  const delayedSearch = useCallback(debounce(() => sendQuery(), 500));
-
-  const handleSearchUserChange = (e) => {
-    setKeywordToSearchUser(e.target.value);
-    delayedSearch();
-  };
-
-  useEffect(() => {
-    sendQuery();
-  }, [keywordToSearchUser]);
+  const { searchedResult } = useGetResult(keywordToSearchUser);
 
   return (
     <>
       <TopSearchNav
         type="text"
         value={keywordToSearchUser}
-        onChange={handleSearchUserChange}
+        onChange={(e) => setKeywordToSearchUser(e.target.value)}
       />
       <SearchWrap>
         <ul>
-          {data.map((data) => {
-            return (
-              <UserListLi key={data._id}>
-                <User
-                  userName={data.username}
-                  userImg={data.image}
-                  userId={data.accountname}
-                  to={`/profile/${data.accountname}`}
-                  state={{ userId: data.accountname }}
-                />
-              </UserListLi>
-            );
-          })}
+          {searchedResult
+            ? searchedResult.map((data) => {
+                return (
+                  <UserListLi key={data._id}>
+                    <User
+                      userName={data.username}
+                      userImg={data.image}
+                      userId={data.accountname}
+                      to={`/profile/${data.accountname}`}
+                      state={{ userId: data.accountname }}
+                    />
+                  </UserListLi>
+                );
+              })
+            : null}
         </ul>
       </SearchWrap>
-
       <TabMenu />
     </>
   );

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -1,23 +1,23 @@
 import React, { useState } from 'react';
 
+import { useGetResult } from '../../hooks/react-query/useSearch';
+
 import { SearchWrap, UserListLi } from './Search.styled';
 
 import TopSearchNav from '../../components/common/Top/TopSearchNav';
 import TabMenu from '../../components/common/Tabmenu/TabMenu';
 import User from '../../components/common/User/User';
 
-import { useGetResult } from '../../hooks/react-query/useSearch';
-
 export default function Search() {
-  const [keywordToSearchUser, setKeywordToSearchUser] = useState('');
-  const { searchedResult } = useGetResult(keywordToSearchUser);
+  const [keyword, setKeyword] = useState('');
+  const { searchedResult } = useGetResult(keyword);
 
   return (
     <>
       <TopSearchNav
         type="text"
-        value={keywordToSearchUser}
-        onChange={(e) => setKeywordToSearchUser(e.target.value)}
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
       />
       <SearchWrap>
         <ul>


### PR DESCRIPTION
## Summary

검색 페이지를 클라이언트, 서버 상태로 분리

## Description

- 서버 상태를 관리하는 리액트 훅 생성
```
const getSearchData = async (keyword) => {
    const res = await instance.get(`/user/searchuser/?keyword=${keyword}`);
    return res.data;
}

export const useGetResult = (keyword) => {
    const { data: searchedResult } = useQuery({
        queryKey: ['keyword', keyword],
        queryFn: () => getSearchData(keyword),
        placeholderData: [],
        enabled: !!keyword,
        select: (data) => data.slice(0, 100),
    })
    return { searchedResult };
}
```
- 서버 상태과 클라이언트 상태를 나누면서 debounce, throttle이 필요없어짐 -> lodash 라이브러리 삭제
- 검색 결과가 많을 경우, 100개까지만 나타내도록 수정

## Checklist

- 문제없이 작동하는지 확인 부탁드립니다.
